### PR TITLE
Don't use exrternref

### DIFF
--- a/store.go
+++ b/store.go
@@ -11,13 +11,20 @@ type ValueType = byte
 const (
 	// ValueTypeI32 is a 32-bit integer.
 	ValueTypeI32 ValueType = 0x7f
+
 	// ValueTypeI64 is a 64-bit integer.
 	ValueTypeI64 ValueType = 0x7e
+
 	// ValueTypeF32 is a 32-bit floating point number.
 	ValueTypeF32 ValueType = 0x7d
+
 	// ValueTypeF64 is a 64-bit floating point number.
 	ValueTypeF64 ValueType = 0x7c
+
 	// ValueTypeExternref is an externref type.
+	//
+	// Not supported by many guests including TinyGo, so we don't use it.
+	// https://github.com/tinygo-org/tinygo/issues/2702
 	ValueTypeExternref ValueType = 0x6f
 )
 

--- a/types_misc.go
+++ b/types_misc.go
@@ -286,7 +286,7 @@ func (v HostRef[T]) Drop() {
 
 // ValueTypes implements [Value] interface.
 func (HostRef[T]) ValueTypes() []ValueType {
-	return []ValueType{ValueTypeExternref}
+	return []ValueType{ValueTypeI32}
 }
 
 // Lift implements [Lift] interface.


### PR DESCRIPTION
TinyGo doesn't support it on the guest (wasm) side: https://github.com/tinygo-org/tinygo/issues/2702