### PR TITLE
types: add List wrapper around generic Go slice that is compatible with component model `List` type

### DIFF
--- a/types_mem.go
+++ b/types_mem.go
@@ -1,5 +1,11 @@
 package wypes
 
+import (
+	"bytes"
+	"encoding/binary"
+	"unsafe"
+)
+
 // Bytes wraps a slice of bytes.
 //
 // The bytes are passed through the linear memory.
@@ -88,6 +94,73 @@ func (v String) Lower(s Store) {
 	s.Stack.Push(Raw(size))
 }
 
-// TODO: arbitrary slice
+// List wraps a Go slice of any type.
+// This is the implementation required for the host side of the component model [cm.List] type.
+// See https://github.com/bytecodealliance/wasm-tools-go/blob/main/cm/list.go
+type List[T int8 | int16 | int32 | int64 | uint8 | uint16 | uint32 | uint64 | float32 | float64] struct {
+	Offset  uint32
+	DataPtr uint32
+	Raw     []T
+}
+
+// Unwrap returns the wrapped value.
+func (v List[T]) Unwrap() []T {
+	return v.Raw
+}
+
+// ValueTypes implements [Value] interface.
+func (v List[T]) ValueTypes() []ValueType {
+	return []ValueType{ValueTypeI32}
+}
+
+// Lift implements [Lift] interface.
+func (List[T]) Lift(s Store) List[T] {
+	offset := uint32(s.Stack.Pop())
+	buf, ok := s.Memory.Read(offset, 8)
+	if !ok {
+		s.Error = ErrMemRead
+		return List[T]{}
+	}
+
+	ptr := binary.LittleEndian.Uint32(buf[0:])
+	sz := binary.LittleEndian.Uint32(buf[4:])
+
+	// empty list, probably a return value to be filled in later.
+	if ptr == 0 || sz == 0 {
+		return List[T]{Offset: offset}
+	}
+
+	raw, ok := s.Memory.Read(ptr, uint32(sz)*uint32(unsafe.Sizeof(T(0))))
+	if !ok {
+		s.Error = ErrMemRead
+		return List[T]{Offset: offset}
+	}
+
+	r := bytes.NewReader(raw)
+	data := make([]T, sz)
+	binary.Read(r, binary.LittleEndian, data)
+
+	return List[T]{Offset: offset, DataPtr: ptr, Raw: data}
+}
+
+// Lower implements [Lower] interface.
+// See https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
+// To use this need to have pre-allocated linear memory into which to write the actual data.
+func (v List[T]) Lower(s Store) {
+	if v.DataPtr == 0 {
+		s.Error = ErrMemWrite
+		return
+	}
+
+	data := new(bytes.Buffer)
+	binary.Write(data, binary.LittleEndian, v.Raw)
+	s.Memory.Write(v.DataPtr, data.Bytes())
+
+	ptrdata := make([]byte, 8)
+	binary.LittleEndian.PutUint32(ptrdata[0:], v.DataPtr)
+	binary.LittleEndian.PutUint32(ptrdata[4:], uint32(len(v.Raw)))
+	s.Memory.Write(v.Offset, ptrdata)
+}
+
 // TODO: fixed-width array
 // TODO: CString

--- a/types_mem_test.go
+++ b/types_mem_test.go
@@ -1,0 +1,75 @@
+package wypes_test
+
+import (
+	"testing"
+
+	"github.com/orsinium-labs/tinytest/is"
+	"github.com/orsinium-labs/wypes"
+)
+
+func TestBytes(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []byte("Hello, World!")
+	wypes.Bytes{Raw: data}.Lower(store)
+
+	result := wypes.Bytes{}.Lift(store)
+	is.SliceEqual(c, result.Unwrap(), data)
+}
+
+func TestListEmpty(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	wypes.List[uint32]{Offset: 64}.Lower(store)
+
+	store.Stack.Push(64)
+	list := wypes.List[uint32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), []uint32{})
+}
+
+func TestListUint32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	wypes.List[uint32]{Offset: 64, Raw: data, DataPtr: 128}.Lower(store)
+
+	store.Stack.Push(64)
+	list := wypes.List[uint32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestListUint16(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	wypes.List[uint16]{Offset: 96, Raw: data, DataPtr: 128}.Lower(store)
+
+	store.Stack.Push(96)
+	list := wypes.List[uint16]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestListFloat32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []float32{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}
+	wypes.List[float32]{Raw: data, DataPtr: 128}.Lower(store)
+
+	store.Stack.Push(0)
+	list := wypes.List[float32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}


### PR DESCRIPTION
This PR adds a `List` type which is a wrapper around generic Go slice. `wypes.List` is intended to be compatible with the component model `List` type.

How to use it:

```go
func sizeFunc(s wypes.Store, list wypes.List[uint32]) wypes.Void {
	list.Raw = []uint32{1, 2, 3, 4}
	list.DataPtr = guestDataPtr // guestDataPtr is address into linear memory that was already allocated
	list.Lower(s)

	return wypes.Void{}
}
```
