### PR TITLE
store, types: a number of important refactorings

### DIFF
--- a/store.go
+++ b/store.go
@@ -207,6 +207,22 @@ type LiftLower[T any] interface {
 	Lower
 }
 
+// MemoryLift reads values from [Store.Memory] into a native Go value.
+type MemoryLift[T any] interface {
+	MemoryLift(Store, Addr) (T, uint32)
+}
+
+// MemoryLower writes a native Go value into the [Store.Memory].
+type MemoryLower[T any] interface {
+	MemoryLower(Store, Addr) uint32
+}
+
+// MemoryLiftLower is a type that implements both [MemoryLift] and [MemoryLower].
+type MemoryLiftLower[T any] interface {
+	MemoryLift[T]
+	MemoryLower[T]
+}
+
 // Modules is a collection of host-defined modules.
 //
 // It maps module names to the module definitions.

--- a/types_int.go
+++ b/types_int.go
@@ -1,7 +1,11 @@
 package wypes
 
+import "encoding/binary"
+
 // Int8 wraps [int8], a signed 8-bit integer.
 type Int8 int8
+
+const Int8Size = 1
 
 // Unwrap returns the wrapped value.
 func (v Int8) Unwrap() int8 {
@@ -23,8 +27,32 @@ func (v Int8) Lower(s Store) {
 	s.Stack.Push(Raw(v))
 }
 
+// MemoryLift implements [MemoryLift] interface.
+func (Int8) MemoryLift(s Store, offset uint32) (Int8, uint32) {
+	raw, ok := s.Memory.Read(offset, Int8Size)
+	if !ok {
+		s.Error = ErrMemRead
+		return Int8(0), 0
+	}
+
+	return Int8(raw[0]), Int8Size
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v Int8) MemoryLower(s Store, offset uint32) (length uint32) {
+	ok := s.Memory.Write(offset, []byte{byte(v)})
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return Int8Size
+}
+
 // Int16 wraps [int16], a signed 16-bit integer.
 type Int16 int16
+
+const Int16Size = 2
 
 // Unwrap returns the wrapped value.
 func (v Int16) Unwrap() int16 {
@@ -46,8 +74,34 @@ func (v Int16) Lower(s Store) {
 	s.Stack.Push(Raw(v))
 }
 
+// MemoryLift implements [MemoryLifter] interface.
+func (Int16) MemoryLift(s Store, offset uint32) (Int16, uint32) {
+	raw, ok := s.Memory.Read(offset, Int16Size)
+	if !ok {
+		s.Error = ErrMemRead
+		return Int16(0), 0
+	}
+
+	return Int16(binary.LittleEndian.Uint16(raw)), Int16Size
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v Int16) MemoryLower(s Store, offset uint32) (length uint32) {
+	data := make([]byte, Int16Size)
+	binary.LittleEndian.PutUint16(data, uint16(v))
+	ok := s.Memory.Write(offset, data)
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return Int16Size
+}
+
 // Int32 wraps [int32], a signed 32-bit integer.
 type Int32 int32
+
+const Int32Size = 4
 
 // Unwrap returns the wrapped value.
 func (v Int32) Unwrap() int32 {
@@ -69,8 +123,34 @@ func (v Int32) Lower(s Store) {
 	s.Stack.Push(Raw(v))
 }
 
+// MemoryLift implements [MemoryLifter] interface.
+func (Int32) MemoryLift(s Store, offset uint32) (Int32, uint32) {
+	raw, ok := s.Memory.Read(offset, Int32Size)
+	if !ok {
+		s.Error = ErrMemRead
+		return Int32(0), 0
+	}
+
+	return Int32(binary.LittleEndian.Uint32(raw)), Int32Size
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v Int32) MemoryLower(s Store, offset uint32) (length uint32) {
+	data := make([]byte, Int32Size)
+	binary.LittleEndian.PutUint32(data, uint32(v))
+	ok := s.Memory.Write(offset, data)
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return Int32Size
+}
+
 // Int64 wraps [int64], a signed 64-bit integer.
 type Int64 int64
+
+const Int64Size = 8
 
 // Unwrap returns the wrapped value.
 func (v Int64) Unwrap() int64 {
@@ -90,6 +170,30 @@ func (Int64) Lift(s Store) Int64 {
 // Lower implements [Lower] interface.
 func (v Int64) Lower(s Store) {
 	s.Stack.Push(Raw(v))
+}
+
+// MemoryLift implements [MemoryLifter] interface.
+func (Int64) MemoryLift(s Store, offset uint32) (Int64, uint32) {
+	raw, ok := s.Memory.Read(offset, Int64Size)
+	if !ok {
+		s.Error = ErrMemRead
+		return Int64(0), 0
+	}
+
+	return Int64(binary.LittleEndian.Uint64(raw)), Int64Size
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v Int64) MemoryLower(s Store, offset uint32) (length uint32) {
+	data := make([]byte, Int64Size)
+	binary.LittleEndian.PutUint64(data, uint64(v))
+	ok := s.Memory.Write(offset, data)
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return Int64Size
 }
 
 // Int wraps [int], a signed 32-bit integer.
@@ -113,4 +217,28 @@ func (Int) Lift(s Store) Int {
 // Lower implements [Lower] interface.
 func (v Int) Lower(s Store) {
 	s.Stack.Push(Raw(v))
+}
+
+// MemoryLift implements [MemoryLifter] interface.
+func (Int) MemoryLift(s Store, offset uint32) (Int, uint32) {
+	raw, ok := s.Memory.Read(offset, Int64Size)
+	if !ok {
+		s.Error = ErrMemRead
+		return Int(0), 0
+	}
+
+	return Int(binary.LittleEndian.Uint64(raw)), Int64Size
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v Int) MemoryLower(s Store, offset uint32) (length uint32) {
+	data := make([]byte, Int64Size)
+	binary.LittleEndian.PutUint64(data, uint64(v))
+	ok := s.Memory.Write(offset, data)
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return Int64Size
 }

--- a/types_mem_test.go
+++ b/types_mem_test.go
@@ -24,12 +24,13 @@ func TestListEmpty(t *testing.T) {
 	stack := wypes.NewSliceStack(4)
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
-	wypes.List[uint32]{Offset: 64}.Lower(store)
+	wypes.List[wypes.UInt32]{Offset: 64}.Lower(store)
 
 	store.Stack.Push(64)
-	list := wypes.List[uint32]{}.Lift(store)
+	store.Stack.Push(0)
+	list := wypes.List[wypes.UInt32]{}.Lift(store)
 
-	is.SliceEqual(c, list.Unwrap(), []uint32{})
+	is.SliceEqual(c, list.Unwrap(), []wypes.UInt32{})
 }
 
 func TestListUint32(t *testing.T) {
@@ -37,11 +38,12 @@ func TestListUint32(t *testing.T) {
 	stack := wypes.NewSliceStack(4)
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
-	data := []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	wypes.List[uint32]{Offset: 64, Raw: data, DataPtr: 128}.Lower(store)
+	data := []wypes.UInt32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	wypes.List[wypes.UInt32]{Offset: 64, Raw: data}.Lower(store)
 
 	store.Stack.Push(64)
-	list := wypes.List[uint32]{}.Lift(store)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.UInt32]{}.Lift(store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -51,11 +53,12 @@ func TestListUint16(t *testing.T) {
 	stack := wypes.NewSliceStack(4)
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
-	data := []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	wypes.List[uint16]{Offset: 96, Raw: data, DataPtr: 128}.Lower(store)
+	data := []wypes.UInt16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	wypes.List[wypes.UInt16]{Offset: 96, Raw: data}.Lower(store)
 
 	store.Stack.Push(96)
-	list := wypes.List[uint16]{}.Lift(store)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.UInt16]{}.Lift(store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -65,11 +68,97 @@ func TestListFloat32(t *testing.T) {
 	stack := wypes.NewSliceStack(4)
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
-	data := []float32{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}
-	wypes.List[float32]{Raw: data, DataPtr: 128}.Lower(store)
+	data := []wypes.Float32{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}
+	wypes.List[wypes.Float32]{Raw: data}.Lower(store)
 
 	store.Stack.Push(0)
-	list := wypes.List[float32]{}.Lift(store)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.Float32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestListBool(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.Bool{true, false, false, true, true, false, true, false, true, false}
+	wypes.List[wypes.Bool]{Offset: 64, Raw: data}.Lower(store)
+
+	store.Stack.Push(64)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.Bool]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestReturnListEmpty(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	wypes.ReturnList[wypes.UInt32]{Offset: 64}.Lower(store)
+
+	store.Stack.Push(64)
+	list := wypes.ReturnList[wypes.UInt32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), []wypes.UInt32{})
+}
+
+func TestReturnListUint32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.UInt32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	wypes.ReturnList[wypes.UInt32]{Offset: 64, Raw: data, DataPtr: 128}.Lower(store)
+
+	store.Stack.Push(64)
+	list := wypes.ReturnList[wypes.UInt32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestReturnListUint16(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.UInt16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	wypes.ReturnList[wypes.UInt16]{Offset: 96, Raw: data, DataPtr: 128}.Lower(store)
+
+	store.Stack.Push(96)
+	list := wypes.ReturnList[wypes.UInt16]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestReturnListFloat32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.Float32{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}
+	wypes.ReturnList[wypes.Float32]{Raw: data, DataPtr: 128}.Lower(store)
+
+	store.Stack.Push(0)
+	list := wypes.ReturnList[wypes.Float32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestListStrings(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []string{"Hello", "World", "!"}
+	wypes.ListStrings{Offset: 64, Raw: data}.Lower(store)
+
+	store.Stack.Push(64)
+	store.Stack.Push(3)
+	list := wypes.ListStrings{}.Lift(store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }

--- a/types_uint.go
+++ b/types_uint.go
@@ -1,7 +1,11 @@
 package wypes
 
+import "encoding/binary"
+
 // UInt8 wraps uint8, 8-bit unsigned integer.
 type UInt8 uint8
+
+const UInt8Size = 1
 
 // Unwrap returns the wrapped value.
 func (v UInt8) Unwrap() uint8 {
@@ -23,8 +27,32 @@ func (v UInt8) Lower(s Store) {
 	s.Stack.Push(Raw(v))
 }
 
+// MemoryLift implements [MemoryLift] interface.
+func (UInt8) MemoryLift(s Store, offset uint32) (UInt8, uint32) {
+	raw, ok := s.Memory.Read(offset, UInt8Size)
+	if !ok {
+		s.Error = ErrMemRead
+		return UInt8(0), 0
+	}
+
+	return UInt8(raw[0]), UInt8Size
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v UInt8) MemoryLower(s Store, offset uint32) (length uint32) {
+	ok := s.Memory.Write(offset, []byte{byte(v)})
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return UInt8Size
+}
+
 // UInt16 wraps uint16, 16-bit unsigned integer.
 type UInt16 uint16
+
+const UInt16Size = 2
 
 // Unwrap returns the wrapped value.
 func (v UInt16) Unwrap() uint16 {
@@ -46,8 +74,34 @@ func (v UInt16) Lower(s Store) {
 	s.Stack.Push(Raw(v))
 }
 
+// MemoryLift implements [MemoryLift] interface.
+func (UInt16) MemoryLift(s Store, offset uint32) (UInt16, uint32) {
+	raw, ok := s.Memory.Read(offset, UInt16Size)
+	if !ok {
+		s.Error = ErrMemRead
+		return UInt16(0), 0
+	}
+
+	return UInt16(binary.LittleEndian.Uint16(raw)), UInt16Size
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v UInt16) MemoryLower(s Store, offset uint32) (length uint32) {
+	data := make([]byte, UInt16Size)
+	binary.LittleEndian.PutUint16(data, uint16(v))
+	ok := s.Memory.Write(offset, data)
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return UInt16Size
+}
+
 // UInt32 wraps uint32, 32-bit unsigned integer.
 type UInt32 uint32
+
+const UInt32Size = 4
 
 // Unwrap returns the wrapped value.
 func (v UInt32) Unwrap() uint32 {
@@ -69,8 +123,34 @@ func (v UInt32) Lower(s Store) {
 	s.Stack.Push(Raw(v))
 }
 
+// MemoryLift implements [MemoryLift] interface.
+func (UInt32) MemoryLift(s Store, offset uint32) (UInt32, uint32) {
+	raw, ok := s.Memory.Read(offset, UInt32Size)
+	if !ok {
+		s.Error = ErrMemRead
+		return UInt32(0), 0
+	}
+
+	return UInt32(binary.LittleEndian.Uint32(raw)), UInt32Size
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v UInt32) MemoryLower(s Store, offset uint32) (length uint32) {
+	data := make([]byte, UInt32Size)
+	binary.LittleEndian.PutUint32(data, uint32(v))
+	ok := s.Memory.Write(offset, data)
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return UInt32Size
+}
+
 // UInt64 wraps uint64, 64-bit unsigned integer.
 type UInt64 uint64
+
+const UInt64Size = 8
 
 // Unwrap returns the wrapped value.
 func (v UInt64) Unwrap() uint64 {
@@ -92,8 +172,34 @@ func (v UInt64) Lower(s Store) {
 	s.Stack.Push(Raw(v))
 }
 
+// MemoryLift implements [MemoryLift] interface.
+func (UInt64) MemoryLift(s Store, offset uint32) (UInt64, uint32) {
+	raw, ok := s.Memory.Read(offset, UInt64Size)
+	if !ok {
+		s.Error = ErrMemRead
+		return UInt64(0), 0
+	}
+
+	return UInt64(binary.LittleEndian.Uint64(raw)), UInt64Size
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v UInt64) MemoryLower(s Store, offset uint32) (length uint32) {
+	data := make([]byte, UInt64Size)
+	binary.LittleEndian.PutUint64(data, uint64(v))
+	ok := s.Memory.Write(offset, data)
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return UInt64Size
+}
+
 // UInt wraps uint, 32-bit unsigned integer.
 type UInt uint
+
+const UIntSize = 8
 
 // Unwrap returns the wrapped value.
 func (v UInt) Unwrap() uint {
@@ -115,8 +221,34 @@ func (v UInt) Lower(s Store) {
 	s.Stack.Push(Raw(v))
 }
 
+// MemoryLift implements [Reader] interface.
+func (UInt) MemoryLift(s Store, offset uint32) (UInt, uint32) {
+	raw, ok := s.Memory.Read(offset, UIntSize)
+	if !ok {
+		s.Error = ErrMemRead
+		return UInt(0), 0
+	}
+
+	return UInt(binary.LittleEndian.Uint64(raw)), UIntSize
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v UInt) MemoryLower(s Store, offset uint32) (length uint32) {
+	data := make([]byte, UIntSize)
+	binary.LittleEndian.PutUint64(data, uint64(v))
+	ok := s.Memory.Write(offset, data)
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return UIntSize
+}
+
 // UIntPtr wraps uintptr, pointer-sized unsigned integer.
 type UIntPtr uintptr
+
+const UIntPtrSize = 8
 
 // Unwrap returns the wrapped value.
 func (v UIntPtr) Unwrap() uintptr {
@@ -136,6 +268,30 @@ func (UIntPtr) Lift(s Store) UIntPtr {
 // Lower implements [Lower] interface.
 func (v UIntPtr) Lower(s Store) {
 	s.Stack.Push(Raw(v))
+}
+
+// MemoryLift implements [MemoryLift] interface.
+func (UIntPtr) MemoryLift(s Store, offset uint32) (UIntPtr, uint32) {
+	raw, ok := s.Memory.Read(offset, UIntPtrSize)
+	if !ok {
+		s.Error = ErrMemRead
+		return UIntPtr(0), 0
+	}
+
+	return UIntPtr(binary.LittleEndian.Uint64(raw)), UIntPtrSize
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v UIntPtr) MemoryLower(s Store, offset uint32) (length uint32) {
+	data := make([]byte, UIntPtrSize)
+	binary.LittleEndian.PutUint64(data, uint64(v))
+	ok := s.Memory.Write(offset, data)
+	if !ok {
+		s.Error = ErrMemRead
+		return 0
+	}
+
+	return UIntPtrSize
 }
 
 // Rune is an alias for [UInt32].


### PR DESCRIPTION
* add MemoryLift and MemoryLower interfaces
* rename wypes.List to wypes.ReturnList since that is what it actually does
* refactor to make wypes.ReturnList properly generic
* add a wypes.List that actually can handle calls that have a List as a parameter.
* add wypes.ListStrings to be able to handle calls that have a list of strings as a parameter.