### PR TITLE
feature: add List[T] type

### DIFF
--- a/types_mem_test.go
+++ b/types_mem_test.go
@@ -101,3 +101,107 @@ func TestReturnedListFloat32(t *testing.T) {
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
+
+func TestListEmpty(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	wypes.List[wypes.UInt32]{Offset: 64}.Lower(store)
+
+	store.Stack.Push(64)
+	store.Stack.Push(0)
+	list := wypes.List[wypes.UInt32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), []wypes.UInt32{})
+}
+
+func TestListUint16(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.UInt16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	wypes.List[wypes.UInt16]{Offset: 96, Raw: data}.Lower(store)
+
+	store.Stack.Push(96)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.UInt16]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestListUint32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.UInt32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	wypes.List[wypes.UInt32]{Offset: 64, Raw: data}.Lower(store)
+
+	store.Stack.Push(64)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.UInt32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestListInt16(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.Int16{1, -2, 3, -4, -5, 6, -7, 8, -9, 10}
+	wypes.List[wypes.Int16]{Offset: 96, Raw: data}.Lower(store)
+
+	store.Stack.Push(96)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.Int16]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestListInt32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.Int32{1, -2, 3, -4, -5, 6, -7, 8, -9, 10}
+	wypes.List[wypes.Int32]{Offset: 64, Raw: data}.Lower(store)
+
+	store.Stack.Push(64)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.Int32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestListFloat32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.Float32{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}
+	wypes.List[wypes.Float32]{Raw: data}.Lower(store)
+
+	store.Stack.Push(0)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.Float32]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}
+
+func TestListBool(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+
+	data := []wypes.Bool{true, false, false, true, true, false, true, false, true, false}
+	wypes.List[wypes.Bool]{Offset: 64, Raw: data}.Lower(store)
+
+	store.Stack.Push(64)
+	store.Stack.Push(10)
+	list := wypes.List[wypes.Bool]{}.Lift(store)
+
+	is.SliceEqual(c, list.Unwrap(), data)
+}


### PR DESCRIPTION
This PR adds a `wypes.List[]` type to support when guest modules call host functions and pass `cm.List[T]` params.

Needed since `wypes.ReturnsList[T]` only handles function calls from guest modules that expect a host function to return a `*cm.List[T]`

This PR will need to be rebased after PR #10 and #11 have been merged.