### PR TITLE
store: pass pointer to Store instead of literal

### DIFF
--- a/host_funcs.go
+++ b/host_funcs.go
@@ -11,7 +11,7 @@ package wypes
 type HostFunc struct {
 	Params  []Value
 	Results []Value
-	Call    func(Store)
+	Call    func(*Store)
 }
 
 func (f *HostFunc) NumParams() int {
@@ -54,7 +54,7 @@ func H0[Z Lower](
 	return HostFunc{
 		Params:  []Value{},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			fn().Lower(s)
 		},
 	}
@@ -69,7 +69,7 @@ func H1[A Lift[A], Z Lower](
 	return HostFunc{
 		Params:  []Value{a},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			a := a.Lift(s)
 			fn(a).Lower(s)
 		},
@@ -86,7 +86,7 @@ func H2[A Lift[A], B Lift[B], Z Lower](
 	return HostFunc{
 		Params:  []Value{a, b},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			b := b.Lift(s)
 			a := a.Lift(s)
 			fn(a, b).Lower(s)
@@ -105,7 +105,7 @@ func H3[A Lift[A], B Lift[B], C Lift[C], Z Lower](
 	return HostFunc{
 		Params:  []Value{a, b, c},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			c := c.Lift(s)
 			b := b.Lift(s)
 			a := a.Lift(s)
@@ -126,7 +126,7 @@ func H4[A Lift[A], B Lift[B], C Lift[C], D Lift[D], Z Lower](
 	return HostFunc{
 		Params:  []Value{a, b, c, d},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			d := d.Lift(s)
 			c := c.Lift(s)
 			b := b.Lift(s)
@@ -149,7 +149,7 @@ func H5[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], Z Lower](
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			e := e.Lift(s)
 			d := d.Lift(s)
 			c := c.Lift(s)
@@ -174,7 +174,7 @@ func H6[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], Z Lowe
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			f := f.Lift(s)
 			e := e.Lift(s)
 			d := d.Lift(s)
@@ -201,7 +201,7 @@ func H7[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lift
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			g := g.Lift(s)
 			f := f.Lift(s)
 			e := e.Lift(s)
@@ -230,7 +230,7 @@ func H8[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lift
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			h := h.Lift(s)
 			g := g.Lift(s)
 			f := f.Lift(s)
@@ -261,7 +261,7 @@ func H9[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lift
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			i := i.Lift(s)
 			h := h.Lift(s)
 			g := g.Lift(s)
@@ -294,7 +294,7 @@ func H10[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lif
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i, j},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			j := j.Lift(s)
 			i := i.Lift(s)
 			h := h.Lift(s)
@@ -329,7 +329,7 @@ func H11[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lif
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i, j, k},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			k := k.Lift(s)
 			j := j.Lift(s)
 			i := i.Lift(s)
@@ -366,7 +366,7 @@ func H12[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lif
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i, j, k, l},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			l := l.Lift(s)
 			k := k.Lift(s)
 			j := j.Lift(s)
@@ -405,7 +405,7 @@ func H13[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lif
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i, j, k, l, m},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			m := m.Lift(s)
 			l := l.Lift(s)
 			k := k.Lift(s)
@@ -446,7 +446,7 @@ func H14[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lif
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i, j, k, l, m, n},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			n := n.Lift(s)
 			m := m.Lift(s)
 			l := l.Lift(s)
@@ -489,7 +489,7 @@ func H15[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lif
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i, j, k, l, m, n, o},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			o := o.Lift(s)
 			n := n.Lift(s)
 			m := m.Lift(s)
@@ -534,7 +534,7 @@ func H16[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lif
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			p := p.Lift(s)
 			o := o.Lift(s)
 			n := n.Lift(s)
@@ -581,7 +581,7 @@ func H17[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lif
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			q := q.Lift(s)
 			p := p.Lift(s)
 			o := o.Lift(s)
@@ -630,7 +630,7 @@ func H18[A Lift[A], B Lift[B], C Lift[C], D Lift[D], E Lift[E], F Lift[F], G Lif
 	return HostFunc{
 		Params:  []Value{a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r},
 		Results: []Value{z},
-		Call: func(s Store) {
+		Call: func(s *Store) {
 			r := r.Lift(s)
 			q := q.Lift(s)
 			p := p.Lift(s)

--- a/host_funcs_test.go
+++ b/host_funcs_test.go
@@ -12,7 +12,7 @@ func TestH0(t *testing.T) {
 	stack := wypes.NewSliceStack(4)
 	store := wypes.Store{Stack: stack}
 	f := wypes.H0(func() wypes.Int { return 13 })
-	f.Call(store)
+	f.Call(&store)
 	is.Equal(c, stack.Pop(), 13)
 }
 
@@ -24,7 +24,7 @@ func TestH1(t *testing.T) {
 	f := wypes.H1(func(x wypes.Int) wypes.Int {
 		return x * 2
 	})
-	f.Call(store)
+	f.Call(&store)
 	is.Equal(c, stack.Pop(), 24)
 }
 
@@ -37,6 +37,6 @@ func TestH2(t *testing.T) {
 	f := wypes.H2(func(a, b wypes.Int) wypes.Int {
 		return a - b
 	})
-	f.Call(store)
+	f.Call(&store)
 	is.Equal(c, stack.Pop(), 6)
 }

--- a/store.go
+++ b/store.go
@@ -51,12 +51,12 @@ type Store struct {
 }
 
 // ValueTypes implements [Value] interface.
-func (Store) ValueTypes() []ValueType {
+func (*Store) ValueTypes() []ValueType {
 	return []ValueType{}
 }
 
 // Lift implements [Lift] interface.
-func (Store) Lift(s Store) Store {
+func (*Store) Lift(s *Store) *Store {
 	return s
 }
 
@@ -192,13 +192,13 @@ type Value interface {
 // Lift reads values from [Store] into a native Go value.
 type Lift[T any] interface {
 	Value
-	Lift(Store) T
+	Lift(*Store) T
 }
 
 // Lower writes a native Go value into the [Store].
 type Lower interface {
 	Value
-	Lower(Store)
+	Lower(*Store)
 }
 
 // LiftLower is a type that implements both [Lift] and [Lower].
@@ -209,12 +209,12 @@ type LiftLower[T any] interface {
 
 // MemoryLift reads values from [Store.Memory] into a native Go value.
 type MemoryLift[T any] interface {
-	MemoryLift(Store, Addr) (T, uint32)
+	MemoryLift(*Store, Addr) (T, uint32)
 }
 
 // MemoryLower writes a native Go value into the [Store.Memory].
 type MemoryLower[T any] interface {
-	MemoryLower(Store, Addr) uint32
+	MemoryLower(*Store, Addr) uint32
 }
 
 // MemoryLiftLower is a type that implements both [MemoryLift] and [MemoryLower].

--- a/types_int.go
+++ b/types_int.go
@@ -18,17 +18,17 @@ func (Int8) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Int8) Lift(s Store) Int8 {
+func (Int8) Lift(s *Store) Int8 {
 	return Int8(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v Int8) Lower(s Store) {
+func (v Int8) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLift] interface.
-func (Int8) MemoryLift(s Store, offset uint32) (Int8, uint32) {
+func (Int8) MemoryLift(s *Store, offset uint32) (Int8, uint32) {
 	raw, ok := s.Memory.Read(offset, int8Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -39,7 +39,7 @@ func (Int8) MemoryLift(s Store, offset uint32) (Int8, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v Int8) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v Int8) MemoryLower(s *Store, offset uint32) (length uint32) {
 	ok := s.Memory.Write(offset, []byte{byte(v)})
 	if !ok {
 		s.Error = ErrMemWrite
@@ -65,17 +65,17 @@ func (Int16) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Int16) Lift(s Store) Int16 {
+func (Int16) Lift(s *Store) Int16 {
 	return Int16(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v Int16) Lower(s Store) {
+func (v Int16) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLifter] interface.
-func (Int16) MemoryLift(s Store, offset uint32) (Int16, uint32) {
+func (Int16) MemoryLift(s *Store, offset uint32) (Int16, uint32) {
 	raw, ok := s.Memory.Read(offset, int16Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -86,7 +86,7 @@ func (Int16) MemoryLift(s Store, offset uint32) (Int16, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v Int16) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v Int16) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, int16Size)
 	binary.LittleEndian.PutUint16(data, uint16(v))
 	ok := s.Memory.Write(offset, data)
@@ -114,17 +114,17 @@ func (Int32) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Int32) Lift(s Store) Int32 {
+func (Int32) Lift(s *Store) Int32 {
 	return Int32(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v Int32) Lower(s Store) {
+func (v Int32) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLifter] interface.
-func (Int32) MemoryLift(s Store, offset uint32) (Int32, uint32) {
+func (Int32) MemoryLift(s *Store, offset uint32) (Int32, uint32) {
 	raw, ok := s.Memory.Read(offset, int32Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -135,7 +135,7 @@ func (Int32) MemoryLift(s Store, offset uint32) (Int32, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v Int32) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v Int32) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, int32Size)
 	binary.LittleEndian.PutUint32(data, uint32(v))
 	ok := s.Memory.Write(offset, data)
@@ -163,17 +163,17 @@ func (Int64) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Int64) Lift(s Store) Int64 {
+func (Int64) Lift(s *Store) Int64 {
 	return Int64(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v Int64) Lower(s Store) {
+func (v Int64) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLifter] interface.
-func (Int64) MemoryLift(s Store, offset uint32) (Int64, uint32) {
+func (Int64) MemoryLift(s *Store, offset uint32) (Int64, uint32) {
 	raw, ok := s.Memory.Read(offset, int64Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -184,7 +184,7 @@ func (Int64) MemoryLift(s Store, offset uint32) (Int64, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v Int64) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v Int64) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, int64Size)
 	binary.LittleEndian.PutUint64(data, uint64(v))
 	ok := s.Memory.Write(offset, data)
@@ -210,17 +210,17 @@ func (Int) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Int) Lift(s Store) Int {
+func (Int) Lift(s *Store) Int {
 	return Int(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v Int) Lower(s Store) {
+func (v Int) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLifter] interface.
-func (Int) MemoryLift(s Store, offset uint32) (Int, uint32) {
+func (Int) MemoryLift(s *Store, offset uint32) (Int, uint32) {
 	raw, ok := s.Memory.Read(offset, int64Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -231,7 +231,7 @@ func (Int) MemoryLift(s Store, offset uint32) (Int, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v Int) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v Int) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, int64Size)
 	binary.LittleEndian.PutUint64(data, uint64(v))
 	ok := s.Memory.Write(offset, data)

--- a/types_mem.go
+++ b/types_mem.go
@@ -27,7 +27,7 @@ func (v Bytes) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Bytes) Lift(s Store) Bytes {
+func (Bytes) Lift(s *Store) Bytes {
 	size := uint32(s.Stack.Pop())
 	offset := uint32(s.Stack.Pop())
 	raw, ok := s.Memory.Read(offset, size)
@@ -38,7 +38,7 @@ func (Bytes) Lift(s Store) Bytes {
 }
 
 // Lower implements [Lower] interface.
-func (v Bytes) Lower(s Store) {
+func (v Bytes) Lower(s *Store) {
 	ok := s.Memory.Write(v.Offset, v.Raw)
 	if !ok {
 		s.Error = ErrMemWrite
@@ -71,7 +71,7 @@ func (v String) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (String) Lift(s Store) String {
+func (String) Lift(s *Store) String {
 	size := uint32(s.Stack.Pop())
 	offset := uint32(s.Stack.Pop())
 	raw, ok := s.Memory.Read(offset, size)
@@ -82,7 +82,7 @@ func (String) Lift(s Store) String {
 }
 
 // Lower implements [Lower] interface.
-func (v String) Lower(s Store) {
+func (v String) Lower(s *Store) {
 	ok := s.Memory.Write(v.Offset, []byte(v.Raw))
 	if !ok {
 		s.Error = ErrMemWrite
@@ -112,7 +112,7 @@ func (v ReturnedList[T]) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (ReturnedList[T]) Lift(s Store) ReturnedList[T] {
+func (ReturnedList[T]) Lift(s *Store) ReturnedList[T] {
 	offset := uint32(s.Stack.Pop())
 	buf, ok := s.Memory.Read(offset, 8)
 	if !ok {
@@ -142,7 +142,7 @@ func (ReturnedList[T]) Lift(s Store) ReturnedList[T] {
 // Lower implements [Lower] interface.
 // See https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
 // To use this need to have pre-allocated linear memory into which to write the actual data.
-func (v ReturnedList[T]) Lower(s Store) {
+func (v ReturnedList[T]) Lower(s *Store) {
 	if v.DataPtr == 0 {
 		s.Error = ErrMemWrite
 		return
@@ -180,7 +180,7 @@ func (v List[T]) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (List[T]) Lift(s Store) List[T] {
+func (List[T]) Lift(s *Store) List[T] {
 	size := uint32(s.Stack.Pop())
 	offset := uint32(s.Stack.Pop())
 	// empty list
@@ -200,7 +200,7 @@ func (List[T]) Lift(s Store) List[T] {
 // Lower implements [Lower] interface.
 // See https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
 // In theory we should re-allocate enough linear memory into which to write the actual data.
-func (v List[T]) Lower(s Store) {
+func (v List[T]) Lower(s *Store) {
 	size := len(v.Raw)
 	ptr := v.Offset
 	for i := uint32(0); i < uint32(size); i++ {
@@ -231,7 +231,7 @@ func (v ListStrings) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (ListStrings) Lift(s Store) ListStrings {
+func (ListStrings) Lift(s *Store) ListStrings {
 	size := uint32(s.Stack.Pop())
 	offset := uint32(s.Stack.Pop())
 
@@ -267,7 +267,7 @@ func (ListStrings) Lift(s Store) ListStrings {
 // Lower implements [Lower] interface.
 // See https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
 // In theory we should re-allocate enough linear memory into which to write the actual data.
-func (v ListStrings) Lower(s Store) {
+func (v ListStrings) Lower(s *Store) {
 	size := uint32(len(v.Raw))
 	plen := size * 8
 

--- a/types_mem_test.go
+++ b/types_mem_test.go
@@ -13,9 +13,9 @@ func TestBytes(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []byte("Hello, World!")
-	wypes.Bytes{Raw: data}.Lower(store)
+	wypes.Bytes{Raw: data}.Lower(&store)
 
-	result := wypes.Bytes{}.Lift(store)
+	result := wypes.Bytes{}.Lift(&store)
 	is.SliceEqual(c, result.Unwrap(), data)
 }
 
@@ -24,10 +24,10 @@ func TestReturnedListEmpty(t *testing.T) {
 	stack := wypes.NewSliceStack(4)
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
-	wypes.ReturnedList[wypes.UInt32]{Offset: 64}.Lower(store)
+	wypes.ReturnedList[wypes.UInt32]{Offset: 64}.Lower(&store)
 
 	store.Stack.Push(64)
-	list := wypes.ReturnedList[wypes.UInt32]{}.Lift(store)
+	list := wypes.ReturnedList[wypes.UInt32]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), []wypes.UInt32{})
 }
@@ -38,10 +38,10 @@ func TestReturnedListUint32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.UInt32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	wypes.ReturnedList[wypes.UInt32]{Offset: 64, Raw: data, DataPtr: 128}.Lower(store)
+	wypes.ReturnedList[wypes.UInt32]{Offset: 64, Raw: data, DataPtr: 128}.Lower(&store)
 
 	store.Stack.Push(64)
-	list := wypes.ReturnedList[wypes.UInt32]{}.Lift(store)
+	list := wypes.ReturnedList[wypes.UInt32]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -52,10 +52,10 @@ func TestReturnedListUint16(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.UInt16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	wypes.ReturnedList[wypes.UInt16]{Offset: 96, Raw: data, DataPtr: 128}.Lower(store)
+	wypes.ReturnedList[wypes.UInt16]{Offset: 96, Raw: data, DataPtr: 128}.Lower(&store)
 
 	store.Stack.Push(96)
-	list := wypes.ReturnedList[wypes.UInt16]{}.Lift(store)
+	list := wypes.ReturnedList[wypes.UInt16]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -66,10 +66,10 @@ func TestReturnedListInt16(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.Int16{1, -2, 3, 4, -5, 6, -7, 8, 9, 10}
-	wypes.ReturnedList[wypes.Int16]{Offset: 64, Raw: data, DataPtr: 128}.Lower(store)
+	wypes.ReturnedList[wypes.Int16]{Offset: 64, Raw: data, DataPtr: 128}.Lower(&store)
 
 	store.Stack.Push(64)
-	list := wypes.ReturnedList[wypes.Int16]{}.Lift(store)
+	list := wypes.ReturnedList[wypes.Int16]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -80,10 +80,10 @@ func TestReturnedListInt32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.Int32{1, -2, 3, 4, -5, 6, -7, 8, 9, 10}
-	wypes.ReturnedList[wypes.Int32]{Offset: 64, Raw: data, DataPtr: 128}.Lower(store)
+	wypes.ReturnedList[wypes.Int32]{Offset: 64, Raw: data, DataPtr: 128}.Lower(&store)
 
 	store.Stack.Push(64)
-	list := wypes.ReturnedList[wypes.Int32]{}.Lift(store)
+	list := wypes.ReturnedList[wypes.Int32]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -94,10 +94,10 @@ func TestReturnedListFloat32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.Float32{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}
-	wypes.ReturnedList[wypes.Float32]{Raw: data, DataPtr: 128}.Lower(store)
+	wypes.ReturnedList[wypes.Float32]{Raw: data, DataPtr: 128}.Lower(&store)
 
 	store.Stack.Push(0)
-	list := wypes.ReturnedList[wypes.Float32]{}.Lift(store)
+	list := wypes.ReturnedList[wypes.Float32]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -107,11 +107,11 @@ func TestListEmpty(t *testing.T) {
 	stack := wypes.NewSliceStack(4)
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
-	wypes.List[wypes.UInt32]{Offset: 64}.Lower(store)
+	wypes.List[wypes.UInt32]{Offset: 64}.Lower(&store)
 
 	store.Stack.Push(64)
 	store.Stack.Push(0)
-	list := wypes.List[wypes.UInt32]{}.Lift(store)
+	list := wypes.List[wypes.UInt32]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), []wypes.UInt32{})
 }
@@ -122,11 +122,11 @@ func TestListUint16(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.UInt16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	wypes.List[wypes.UInt16]{Offset: 96, Raw: data}.Lower(store)
+	wypes.List[wypes.UInt16]{Offset: 96, Raw: data}.Lower(&store)
 
 	store.Stack.Push(96)
 	store.Stack.Push(10)
-	list := wypes.List[wypes.UInt16]{}.Lift(store)
+	list := wypes.List[wypes.UInt16]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -137,11 +137,11 @@ func TestListUint32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.UInt32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	wypes.List[wypes.UInt32]{Offset: 64, Raw: data}.Lower(store)
+	wypes.List[wypes.UInt32]{Offset: 64, Raw: data}.Lower(&store)
 
 	store.Stack.Push(64)
 	store.Stack.Push(10)
-	list := wypes.List[wypes.UInt32]{}.Lift(store)
+	list := wypes.List[wypes.UInt32]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -152,11 +152,11 @@ func TestListInt16(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.Int16{1, -2, 3, -4, -5, 6, -7, 8, -9, 10}
-	wypes.List[wypes.Int16]{Offset: 96, Raw: data}.Lower(store)
+	wypes.List[wypes.Int16]{Offset: 96, Raw: data}.Lower(&store)
 
 	store.Stack.Push(96)
 	store.Stack.Push(10)
-	list := wypes.List[wypes.Int16]{}.Lift(store)
+	list := wypes.List[wypes.Int16]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -167,11 +167,11 @@ func TestListInt32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.Int32{1, -2, 3, -4, -5, 6, -7, 8, -9, 10}
-	wypes.List[wypes.Int32]{Offset: 64, Raw: data}.Lower(store)
+	wypes.List[wypes.Int32]{Offset: 64, Raw: data}.Lower(&store)
 
 	store.Stack.Push(64)
 	store.Stack.Push(10)
-	list := wypes.List[wypes.Int32]{}.Lift(store)
+	list := wypes.List[wypes.Int32]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -182,11 +182,11 @@ func TestListFloat32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.Float32{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}
-	wypes.List[wypes.Float32]{Raw: data}.Lower(store)
+	wypes.List[wypes.Float32]{Raw: data}.Lower(&store)
 
 	store.Stack.Push(0)
 	store.Stack.Push(10)
-	list := wypes.List[wypes.Float32]{}.Lift(store)
+	list := wypes.List[wypes.Float32]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -197,11 +197,11 @@ func TestListBool(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []wypes.Bool{true, false, false, true, true, false, true, false, true, false}
-	wypes.List[wypes.Bool]{Offset: 64, Raw: data}.Lower(store)
+	wypes.List[wypes.Bool]{Offset: 64, Raw: data}.Lower(&store)
 
 	store.Stack.Push(64)
 	store.Stack.Push(10)
-	list := wypes.List[wypes.Bool]{}.Lift(store)
+	list := wypes.List[wypes.Bool]{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -212,11 +212,11 @@ func TestListEmptyStrings(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []string{}
-	wypes.ListStrings{Offset: 64, Raw: data}.Lower(store)
+	wypes.ListStrings{Offset: 64, Raw: data}.Lower(&store)
 
 	store.Stack.Push(64)
 	store.Stack.Push(uint64(len(data)))
-	list := wypes.ListStrings{}.Lift(store)
+	list := wypes.ListStrings{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
@@ -227,11 +227,11 @@ func TestListStrings(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 
 	data := []string{"Hello", "World", "!"}
-	wypes.ListStrings{Offset: 64, Raw: data}.Lower(store)
+	wypes.ListStrings{Offset: 64, Raw: data}.Lower(&store)
 
 	store.Stack.Push(64)
 	store.Stack.Push(uint64(len(data)))
-	list := wypes.ListStrings{}.Lift(store)
+	list := wypes.ListStrings{}.Lift(&store)
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }

--- a/types_misc.go
+++ b/types_misc.go
@@ -23,12 +23,12 @@ func (Bool) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Bool) Lift(s Store) Bool {
+func (Bool) Lift(s *Store) Bool {
 	return s.Stack.Pop() != 0
 }
 
 // Lower implements [Lower] interface.
-func (v Bool) Lower(s Store) {
+func (v Bool) Lower(s *Store) {
 	res := 0
 	if v {
 		res = 1
@@ -37,7 +37,7 @@ func (v Bool) Lower(s Store) {
 }
 
 // MemoryLift implements [MemoryLift] interface.
-func (Bool) MemoryLift(s Store, offset uint32) (Bool, uint32) {
+func (Bool) MemoryLift(s *Store, offset uint32) (Bool, uint32) {
 	raw, ok := s.Memory.Read(offset, BoolSize)
 	if !ok {
 		s.Error = ErrMemRead
@@ -48,7 +48,7 @@ func (Bool) MemoryLift(s Store, offset uint32) (Bool, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v Bool) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v Bool) MemoryLower(s *Store, offset uint32) (length uint32) {
 	res := 0
 	if v {
 		res = 1
@@ -78,19 +78,19 @@ func (Float32) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Float32) Lift(s Store) Float32 {
+func (Float32) Lift(s *Store) Float32 {
 	f := math.Float32frombits(uint32(s.Stack.Pop()))
 	return Float32(f)
 }
 
 // Lower implements [Lower] interface.
-func (v Float32) Lower(s Store) {
+func (v Float32) Lower(s *Store) {
 	r := math.Float32bits(float32(v))
 	s.Stack.Push(Raw(r))
 }
 
 // MemoryLift implements [MemoryLift] interface.
-func (Float32) MemoryLift(s Store, offset uint32) (Float32, uint32) {
+func (Float32) MemoryLift(s *Store, offset uint32) (Float32, uint32) {
 	raw, ok := s.Memory.Read(offset, Float32Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -101,7 +101,7 @@ func (Float32) MemoryLift(s Store, offset uint32) (Float32, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v Float32) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v Float32) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, Float32Size)
 	binary.LittleEndian.PutUint32(data, math.Float32bits(float32(v)))
 	ok := s.Memory.Write(offset, data)
@@ -129,19 +129,19 @@ func (Float64) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Float64) Lift(s Store) Float64 {
+func (Float64) Lift(s *Store) Float64 {
 	f := math.Float64frombits(s.Stack.Pop())
 	return Float64(f)
 }
 
 // Lower implements [Lower] interface.
-func (v Float64) Lower(s Store) {
+func (v Float64) Lower(s *Store) {
 	res := math.Float64bits(float64(v))
 	s.Stack.Push(Raw(res))
 }
 
 // MemoryLift implements [MemoryLift] interface.
-func (Float64) MemoryLift(s Store, offset uint32) (Float64, uint32) {
+func (Float64) MemoryLift(s *Store, offset uint32) (Float64, uint32) {
 	raw, ok := s.Memory.Read(offset, Float64Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -152,7 +152,7 @@ func (Float64) MemoryLift(s Store, offset uint32) (Float64, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v Float64) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v Float64) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, Float64Size)
 	binary.LittleEndian.PutUint64(data, math.Float64bits(float64(v)))
 	ok := s.Memory.Write(offset, data)
@@ -178,7 +178,7 @@ func (Complex64) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Complex64) Lift(s Store) Complex64 {
+func (Complex64) Lift(s *Store) Complex64 {
 	c := complex(
 		math.Float32frombits(uint32(s.Stack.Pop())),
 		math.Float32frombits(uint32(s.Stack.Pop())),
@@ -187,7 +187,7 @@ func (Complex64) Lift(s Store) Complex64 {
 }
 
 // Lower implements [Lower] interface.
-func (v Complex64) Lower(s Store) {
+func (v Complex64) Lower(s *Store) {
 	vReal := math.Float32bits(real(v))
 	vImag := math.Float32bits(imag(v))
 	s.Stack.Push(Raw(vReal))
@@ -208,7 +208,7 @@ func (Complex128) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Complex128) Lift(s Store) Complex128 {
+func (Complex128) Lift(s *Store) Complex128 {
 	c := complex(
 		math.Float64frombits(uint64(s.Stack.Pop())),
 		math.Float64frombits(uint64(s.Stack.Pop())),
@@ -217,7 +217,7 @@ func (Complex128) Lift(s Store) Complex128 {
 }
 
 // Lower implements [Lower] interface.
-func (v Complex128) Lower(s Store) {
+func (v Complex128) Lower(s *Store) {
 	vReal := math.Float64bits(real(v))
 	vImag := math.Float64bits(imag(v))
 	s.Stack.Push(Raw(vReal))
@@ -238,12 +238,12 @@ func (Duration) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Duration) Lift(s Store) Duration {
+func (Duration) Lift(s *Store) Duration {
 	return Duration(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v Duration) Lower(s Store) {
+func (v Duration) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
@@ -261,12 +261,12 @@ func (Time) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Time) Lift(s Store) Time {
+func (Time) Lift(s *Store) Time {
 	return Time(time.Unix(int64(s.Stack.Pop()), 0))
 }
 
 // Lower implements [Lower] interface.
-func (v Time) Lower(s Store) {
+func (v Time) Lower(s *Store) {
 	s.Stack.Push(Raw(time.Time(v).Unix()))
 }
 
@@ -297,7 +297,7 @@ func (Void) ValueTypes() []ValueType {
 }
 
 // Lower implements [Lower] interface.
-func (Void) Lower(s Store) {}
+func (Void) Lower(s *Store) {}
 
 // Pair wraps two values of arbitrary types.
 //
@@ -317,7 +317,7 @@ func (v Pair[L, R]) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (Pair[L, R]) Lift(s Store) Pair[L, R] {
+func (Pair[L, R]) Lift(s *Store) Pair[L, R] {
 	var left L
 	var right R
 	return Pair[L, R]{
@@ -327,7 +327,7 @@ func (Pair[L, R]) Lift(s Store) Pair[L, R] {
 }
 
 // Lower implements [Lower] interface.
-func (v Pair[L, R]) Lower(s Store) {
+func (v Pair[L, R]) Lower(s *Store) {
 	v.Left.Lower(s)
 	v.Right.Lower(s)
 }
@@ -371,7 +371,7 @@ func (HostRef[T]) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (HostRef[T]) Lift(s Store) HostRef[T] {
+func (HostRef[T]) Lift(s *Store) HostRef[T] {
 	index := uint32(s.Stack.Pop())
 	var def T
 	raw, found := s.Refs.Get(index, def)
@@ -391,7 +391,7 @@ func (HostRef[T]) Lift(s Store) HostRef[T] {
 }
 
 // Lower implements [Lower] interface.
-func (v HostRef[T]) Lower(s Store) {
+func (v HostRef[T]) Lower(s *Store) {
 	var index uint32
 	if v.index == 0 {
 		index = s.Refs.Put(v.Raw)

--- a/types_test.go
+++ b/types_test.go
@@ -18,11 +18,11 @@ func testRoundtrip[T wypes.LiftLower[T]](t *testing.T) {
 
 	// lift, stack should be empty
 	var i T
-	i = i.Lift(store)
+	i = i.Lift(&store)
 	is.Equal(c, stack.Len(), 0)
 
 	// lower, it should put the value on the stack
-	i.Lower(store)
+	i.Lower(&store)
 	is.Equal(c, stack.Len(), 1)
 
 	// pop from the stack and check the value
@@ -64,11 +64,11 @@ func testRoundtripPair[T wypes.LiftLower[T]](t *testing.T) {
 
 	// lift, stack should be empty
 	var i T
-	i = i.Lift(store)
+	i = i.Lift(&store)
 	is.Equal(c, stack.Len(), 0)
 
 	// lower, it should put the values on the stack
-	i.Lower(store)
+	i.Lower(&store)
 	is.Equal(c, stack.Len(), 2)
 
 	// pop from the stack and check the value
@@ -114,7 +114,7 @@ func TestString_Lift(t *testing.T) {
 	stack.Push(3) // offset
 	stack.Push(6) // len
 	var typ wypes.String
-	val := typ.Lift(store)
+	val := typ.Lift(&store)
 	is.Equal(c, val.Unwrap(), "hello!")
 }
 
@@ -128,8 +128,8 @@ func TestString_Lower(t *testing.T) {
 		Offset: 3,
 		Raw:    "hello!",
 	}
-	val1.Lower(store)
-	val2 := val1.Lift(store)
+	val1.Lower(&store)
+	val2 := val1.Lift(&store)
 	is.Equal(c, val2.Unwrap(), "hello!")
 }
 
@@ -143,7 +143,7 @@ func TestBytes_Lift(t *testing.T) {
 	stack.Push(3) // offset
 	stack.Push(6) // len
 	var typ wypes.Bytes
-	val := typ.Lift(store)
+	val := typ.Lift(&store)
 	is.SliceEqual(c, val.Unwrap(), []byte("hello!"))
 }
 
@@ -158,8 +158,8 @@ func TestBytes_Lower(t *testing.T) {
 		Offset: 3,
 		Raw:    []byte("hello!"),
 	}
-	val1.Lower(store)
-	val2 := val1.Lift(store)
+	val1.Lower(&store)
+	val2 := val1.Lift(&store)
 	is.SliceEqual(c, val2.Unwrap(), []byte("hello!"))
 }
 
@@ -176,9 +176,9 @@ func TestHostRef_Lower(t *testing.T) {
 	}
 	val1 := wypes.HostRef[user]{Raw: user{"aragorn"}}
 	val2 := wypes.HostRef[user]{Raw: user{"gandalf"}}
-	val1.Lower(store)
-	val2.Lower(store)
-	val3 := val2.Lift(store)
+	val1.Lower(&store)
+	val2.Lower(&store)
+	val3 := val2.Lift(&store)
 	is.Equal(c, val3.Unwrap(), user{"gandalf"})
 }
 
@@ -190,8 +190,8 @@ func TestHostRef_Drop(t *testing.T) {
 		Refs:  refs,
 	}
 	val1 := wypes.HostRef[user]{Raw: user{"aragorn"}}
-	val1.Lower(store)
-	val2 := val1.Lift(store)
+	val1.Lower(&store)
+	val2 := val1.Lift(&store)
 	is.Equal(c, val2.Unwrap(), user{"aragorn"})
 	is.Equal(c, len(refs.Raw), 1)
 	val2.Drop()

--- a/types_uint.go
+++ b/types_uint.go
@@ -18,17 +18,17 @@ func (UInt8) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (UInt8) Lift(s Store) UInt8 {
+func (UInt8) Lift(s *Store) UInt8 {
 	return UInt8(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v UInt8) Lower(s Store) {
+func (v UInt8) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLift] interface.
-func (UInt8) MemoryLift(s Store, offset uint32) (UInt8, uint32) {
+func (UInt8) MemoryLift(s *Store, offset uint32) (UInt8, uint32) {
 	raw, ok := s.Memory.Read(offset, uInt8Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -39,7 +39,7 @@ func (UInt8) MemoryLift(s Store, offset uint32) (UInt8, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v UInt8) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v UInt8) MemoryLower(s *Store, offset uint32) (length uint32) {
 	ok := s.Memory.Write(offset, []byte{byte(v)})
 	if !ok {
 		s.Error = ErrMemWrite
@@ -65,17 +65,17 @@ func (UInt16) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (UInt16) Lift(s Store) UInt16 {
+func (UInt16) Lift(s *Store) UInt16 {
 	return UInt16(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v UInt16) Lower(s Store) {
+func (v UInt16) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLift] interface.
-func (UInt16) MemoryLift(s Store, offset uint32) (UInt16, uint32) {
+func (UInt16) MemoryLift(s *Store, offset uint32) (UInt16, uint32) {
 	raw, ok := s.Memory.Read(offset, uInt16Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -86,7 +86,7 @@ func (UInt16) MemoryLift(s Store, offset uint32) (UInt16, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v UInt16) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v UInt16) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, uInt16Size)
 	binary.LittleEndian.PutUint16(data, uint16(v))
 	ok := s.Memory.Write(offset, data)
@@ -114,17 +114,17 @@ func (UInt32) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (UInt32) Lift(s Store) UInt32 {
+func (UInt32) Lift(s *Store) UInt32 {
 	return UInt32(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v UInt32) Lower(s Store) {
+func (v UInt32) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLift] interface.
-func (UInt32) MemoryLift(s Store, offset uint32) (UInt32, uint32) {
+func (UInt32) MemoryLift(s *Store, offset uint32) (UInt32, uint32) {
 	raw, ok := s.Memory.Read(offset, uInt32Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -135,7 +135,7 @@ func (UInt32) MemoryLift(s Store, offset uint32) (UInt32, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v UInt32) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v UInt32) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, uInt32Size)
 	binary.LittleEndian.PutUint32(data, uint32(v))
 	ok := s.Memory.Write(offset, data)
@@ -163,17 +163,17 @@ func (UInt64) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (UInt64) Lift(s Store) UInt64 {
+func (UInt64) Lift(s *Store) UInt64 {
 	return UInt64(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v UInt64) Lower(s Store) {
+func (v UInt64) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLift] interface.
-func (UInt64) MemoryLift(s Store, offset uint32) (UInt64, uint32) {
+func (UInt64) MemoryLift(s *Store, offset uint32) (UInt64, uint32) {
 	raw, ok := s.Memory.Read(offset, uInt64Size)
 	if !ok {
 		s.Error = ErrMemRead
@@ -184,7 +184,7 @@ func (UInt64) MemoryLift(s Store, offset uint32) (UInt64, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v UInt64) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v UInt64) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, uInt64Size)
 	binary.LittleEndian.PutUint64(data, uint64(v))
 	ok := s.Memory.Write(offset, data)
@@ -212,17 +212,17 @@ func (UInt) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (UInt) Lift(s Store) UInt {
+func (UInt) Lift(s *Store) UInt {
 	return UInt(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v UInt) Lower(s Store) {
+func (v UInt) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [Reader] interface.
-func (UInt) MemoryLift(s Store, offset uint32) (UInt, uint32) {
+func (UInt) MemoryLift(s *Store, offset uint32) (UInt, uint32) {
 	raw, ok := s.Memory.Read(offset, uIntSize)
 	if !ok {
 		s.Error = ErrMemRead
@@ -233,7 +233,7 @@ func (UInt) MemoryLift(s Store, offset uint32) (UInt, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v UInt) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v UInt) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, uIntSize)
 	binary.LittleEndian.PutUint64(data, uint64(v))
 	ok := s.Memory.Write(offset, data)
@@ -261,17 +261,17 @@ func (UIntPtr) ValueTypes() []ValueType {
 }
 
 // Lift implements [Lift] interface.
-func (UIntPtr) Lift(s Store) UIntPtr {
+func (UIntPtr) Lift(s *Store) UIntPtr {
 	return UIntPtr(s.Stack.Pop())
 }
 
 // Lower implements [Lower] interface.
-func (v UIntPtr) Lower(s Store) {
+func (v UIntPtr) Lower(s *Store) {
 	s.Stack.Push(Raw(v))
 }
 
 // MemoryLift implements [MemoryLift] interface.
-func (UIntPtr) MemoryLift(s Store, offset uint32) (UIntPtr, uint32) {
+func (UIntPtr) MemoryLift(s *Store, offset uint32) (UIntPtr, uint32) {
 	raw, ok := s.Memory.Read(offset, uIntPtrSize)
 	if !ok {
 		s.Error = ErrMemRead
@@ -282,7 +282,7 @@ func (UIntPtr) MemoryLift(s Store, offset uint32) (UIntPtr, uint32) {
 }
 
 // MemoryLower implements [MemoryLower] interface.
-func (v UIntPtr) MemoryLower(s Store, offset uint32) (length uint32) {
+func (v UIntPtr) MemoryLower(s *Store, offset uint32) (length uint32) {
 	data := make([]byte, uIntPtrSize)
 	binary.LittleEndian.PutUint64(data, uint64(v))
 	ok := s.Memory.Write(offset, data)

--- a/wazero.go
+++ b/wazero.go
@@ -50,6 +50,6 @@ func wazeroAdaptHostFunc(hf HostFunc, refs Refs) api.GoModuleFunction {
 			Refs:    refs,
 			Context: ctx,
 		}
-		hf.Call(store)
+		hf.Call(&store)
 	})
 }


### PR DESCRIPTION
This PR addresses the problem of passing literal instead of pointer to function calls, resulting in issues like the Store `Error` cannot be set correctly on errors when calling `Lift` or `Load`.

Note that this PR depends on all the other outstanding PRs.