### PR TITLE
types: add new type wypes.Result

### DIFF
--- a/types_mem.go
+++ b/types_mem.go
@@ -48,6 +48,41 @@ func (v Bytes) Lower(s *Store) {
 	s.Stack.Push(Raw(size))
 }
 
+// MemoryLift implements [MemoryLift] interface.
+func (Bytes) MemoryLift(s *Store, offset uint32) (Bytes, uint32) {
+	sp, ok := s.Memory.Read(offset, 8)
+	if !ok {
+		s.Error = ErrMemRead
+		return Bytes{}, 0
+	}
+	ptr := binary.LittleEndian.Uint32(sp[0:])
+	sz := binary.LittleEndian.Uint32(sp[4:])
+
+	raw, ok := s.Memory.Read(ptr, sz)
+	if !ok {
+		s.Error = ErrMemRead
+		return Bytes{}, 0
+	}
+	return Bytes{Offset: offset, Raw: raw}, sz
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v Bytes) MemoryLower(s *Store, offset uint32) (length uint32) {
+	ptrdata := make([]byte, 8)
+	binary.LittleEndian.PutUint32(ptrdata[0:], offset+8)
+	binary.LittleEndian.PutUint32(ptrdata[4:], uint32(len(v.Raw)))
+
+	ok := s.Memory.Write(offset, ptrdata)
+	if !ok {
+		s.Error = ErrMemWrite
+	}
+	ok = s.Memory.Write(offset+8, v.Raw)
+	if !ok {
+		s.Error = ErrMemWrite
+	}
+	return uint32(len(v.Raw))
+}
+
 // String wraps [string].
 //
 // The string is passed through the linear memory.
@@ -90,6 +125,41 @@ func (v String) Lower(s *Store) {
 	size := len(v.Raw)
 	s.Stack.Push(Raw(v.Offset))
 	s.Stack.Push(Raw(size))
+}
+
+// MemoryLift implements [MemoryLift] interface.
+func (String) MemoryLift(s *Store, offset uint32) (String, uint32) {
+	sp, ok := s.Memory.Read(offset, 8)
+	if !ok {
+		s.Error = ErrMemRead
+		return String{}, 0
+	}
+	ptr := binary.LittleEndian.Uint32(sp[0:])
+	sz := binary.LittleEndian.Uint32(sp[4:])
+
+	raw, ok := s.Memory.Read(ptr, sz)
+	if !ok {
+		s.Error = ErrMemRead
+		return String{}, 0
+	}
+	return String{Offset: offset, Raw: string(raw)}, sz
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v String) MemoryLower(s *Store, offset uint32) (length uint32) {
+	ptrdata := make([]byte, 8)
+	binary.LittleEndian.PutUint32(ptrdata[0:], offset+8)
+	binary.LittleEndian.PutUint32(ptrdata[4:], uint32(len(v.Raw)))
+
+	ok := s.Memory.Write(offset, ptrdata)
+	if !ok {
+		s.Error = ErrMemWrite
+	}
+	ok = s.Memory.Write(offset+8, []byte(v.Raw))
+	if !ok {
+		s.Error = ErrMemWrite
+	}
+	return uint32(len(v.Raw))
 }
 
 // ReturnedList wraps a Go slice of any type that supports the [MemoryLiftLower] interface so it can be returned as a List.
@@ -211,6 +281,48 @@ func (v List[T]) Lower(s *Store) {
 	s.Stack.Push(Raw(size))
 }
 
+// MemoryLift implements [MemoryLift] interface.
+func (List[T]) MemoryLift(s *Store, offset uint32) (List[T], uint32) {
+	sp, ok := s.Memory.Read(offset, 4)
+	if !ok {
+		s.Error = ErrMemRead
+		return List[T]{}, 0
+	}
+	sz := binary.LittleEndian.Uint32(sp[0:])
+
+	ptr := offset + 4
+	data := make([]T, sz)
+	var v T
+	var length uint32
+	for i := uint32(0); i < uint32(sz); i++ {
+		data[i], length = v.MemoryLift(s, ptr)
+		ptr += length
+	}
+
+	return List[T]{Offset: offset, Raw: data}, sz
+}
+
+// MemoryLower implements [MemoryLower] interface.
+func (v List[T]) MemoryLower(s *Store, offset uint32) (length uint32) {
+	sz := len(v.Raw)
+
+	ptr := offset + 4
+	for i := uint32(0); i < uint32(sz); i++ {
+		length := v.Raw[i].MemoryLower(s, ptr)
+		ptr += length
+	}
+
+	ptrdata := make([]byte, 4)
+	binary.LittleEndian.PutUint32(ptrdata[0:], uint32(sz))
+
+	ok := s.Memory.Write(offset, ptrdata)
+	if !ok {
+		s.Error = ErrMemWrite
+	}
+
+	return uint32(sz)
+}
+
 // ListStrings wraps a Go slice of strings.
 // This is the implementation required for the host side of component model functions that pass [cm.List] of strings
 // as parameters.
@@ -297,6 +409,79 @@ func (v ListStrings) Lower(s *Store) {
 
 	s.Stack.Push(Raw(v.Offset))
 	s.Stack.Push(Raw(size))
+}
+
+// Result is the implementation required for the host side of component model functions that return a *[cm.Result] type.
+// See https://github.com/bytecodealliance/wasm-tools-go/blob/main/cm/result.go
+type Result[Shape MemoryLiftLower[Shape], OK MemoryLiftLower[OK], Err MemoryLiftLower[Err]] struct {
+	Offset  uint32
+	DataPtr uint32
+	OK      OK
+	Error   Err
+	IsError bool
+}
+
+// Unwrap returns the wrapped value.
+func (v Result[Shape, OK, Err]) Unwrap() any {
+	if v.IsError {
+		return v.Error
+	}
+
+	return v.OK
+}
+
+// ValueTypes implements [Value] interface.
+func (v Result[Shape, OK, Err]) ValueTypes() []ValueType {
+	return []ValueType{ValueTypeI32}
+}
+
+// Lift implements [Lift] interface. Lifting a result is not supported.
+func (Result[Shape, OK, Err]) Lift(s *Store) Result[Shape, OK, Err] {
+	offset := uint32(s.Stack.Pop())
+
+	var B UInt32
+	isError, sz := B.MemoryLift(s, offset)
+
+	if isError > 0 {
+		var E Err
+		err, _ := E.MemoryLift(s, offset+sz)
+		return Result[Shape, OK, Err]{
+			IsError: true,
+			Error:   err,
+			Offset:  offset,
+		}
+	}
+
+	var T OK
+	val, _ := T.MemoryLift(s, offset+sz)
+	return Result[Shape, OK, Err]{
+		IsError: false,
+		OK:      val,
+		Offset:  offset,
+	}
+}
+
+// Lower implements [Lower] interface.
+// See https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
+// To use this need to have pre-allocated linear memory into which to write the actual data.
+func (v Result[Shape, OK, Err]) Lower(s *Store) {
+	if v.DataPtr == 0 {
+		s.Error = ErrMemWrite
+		return
+	}
+
+	var isError UInt32
+	if v.IsError {
+		isError = 1
+	}
+	sz := isError.MemoryLower(s, v.Offset)
+
+	switch v.IsError {
+	case true:
+		v.Error.MemoryLower(s, v.Offset+sz)
+	case false:
+		v.OK.MemoryLower(s, v.Offset+sz)
+	}
 }
 
 // TODO: fixed-width array

--- a/types_mem_test.go
+++ b/types_mem_test.go
@@ -235,3 +235,140 @@ func TestListStrings(t *testing.T) {
 
 	is.SliceEqual(c, list.Unwrap(), data)
 }
+
+func TestResultOKUInt32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+	save := wypes.Result[wypes.UInt32, wypes.UInt32, wypes.UInt32]{
+		IsError: false,
+		OK:      1,
+		Offset:  64,
+		DataPtr: 128,
+	}
+
+	save.Lower(&store)
+	store.Stack.Push(64)
+	result := wypes.Result[wypes.UInt32, wypes.UInt32, wypes.UInt32]{}.Lift(&store)
+
+	is.Equal(c, result.IsError, false)
+	is.Equal(c, result.OK, wypes.UInt32(1))
+}
+
+func TestResultErrUInt32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+	save := wypes.Result[wypes.UInt32, wypes.UInt32, wypes.UInt32]{
+		IsError: true,
+		Error:   1,
+		Offset:  64,
+		DataPtr: 128,
+	}
+
+	save.Lower(&store)
+	store.Stack.Push(64)
+	result := wypes.Result[wypes.UInt32, wypes.UInt32, wypes.UInt32]{}.Lift(&store)
+
+	is.Equal(c, result.IsError, true)
+	is.Equal(c, result.Error, wypes.UInt32(1))
+}
+
+func TestResultOKStringUInt32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+	save := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{
+		IsError: false,
+		OK:      wypes.String{Raw: "awesome"},
+		Error:   wypes.UInt32(0),
+		Offset:  64,
+		DataPtr: 128,
+	}
+
+	save.Lower(&store)
+	store.Stack.Push(64)
+	result := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{}.Lift(&store)
+
+	is.Equal(c, result.IsError, false)
+	is.Equal(c, result.OK.Unwrap(), "awesome")
+}
+
+func TestResultErrStringUInt32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+	save := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{
+		IsError: true,
+		OK:      wypes.String{Raw: "awesome"},
+		Error:   wypes.UInt32(100),
+		Offset:  64,
+		DataPtr: 128,
+	}
+
+	save.Lower(&store)
+	store.Stack.Push(64)
+	result := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{}.Lift(&store)
+
+	is.Equal(c, result.IsError, true)
+	is.Equal(c, result.Error.Unwrap(), 100)
+}
+
+func TestResultOKListUInt32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+	save := wypes.Result[wypes.List[wypes.UInt32], wypes.List[wypes.UInt32], wypes.UInt32]{
+		IsError: false,
+		OK:      wypes.List[wypes.UInt32]{Raw: []wypes.UInt32{1, 2, 3, 4, 5}},
+		Error:   wypes.UInt32(0),
+		Offset:  64,
+		DataPtr: 128,
+	}
+
+	save.Lower(&store)
+	store.Stack.Push(64)
+	result := wypes.Result[wypes.List[wypes.UInt32], wypes.List[wypes.UInt32], wypes.UInt32]{}.Lift(&store)
+
+	is.Equal(c, result.IsError, false)
+	is.SliceEqual(c, result.OK.Raw, []wypes.UInt32{1, 2, 3, 4, 5})
+}
+
+func TestResultErrListUInt32(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+	save := wypes.Result[wypes.List[wypes.UInt32], wypes.List[wypes.UInt32], wypes.String]{
+		IsError: true,
+		Error:   wypes.String{Raw: "error"},
+		Offset:  64,
+		DataPtr: 128,
+	}
+
+	save.Lower(&store)
+	store.Stack.Push(64)
+	result := wypes.Result[wypes.List[wypes.UInt32], wypes.List[wypes.UInt32], wypes.String]{}.Lift(&store)
+
+	is.Equal(c, result.IsError, true)
+	is.Equal(c, result.Error.Unwrap(), "error")
+}
+
+func TestResultOKBytes(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+	save := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{
+		IsError: false,
+		OK:      wypes.Bytes{Raw: []byte{1, 2, 3, 4, 5}},
+		Error:   wypes.UInt32(0),
+		Offset:  64,
+		DataPtr: 128,
+	}
+
+	save.Lower(&store)
+	store.Stack.Push(64)
+	result := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{}.Lift(&store)
+
+	is.Equal(c, result.IsError, false)
+	is.SliceEqual(c, result.OK.Raw, []byte{1, 2, 3, 4, 5})
+}

--- a/types_misc.go
+++ b/types_misc.go
@@ -44,16 +44,17 @@ func (Bool) MemoryLift(s *Store, offset uint32) (Bool, uint32) {
 		return Bool(false), 0
 	}
 
-	return Bool(raw[0] == 1), BoolSize
+	return Bool(raw[0] > 0), BoolSize
 }
 
 // MemoryLower implements [MemoryLower] interface.
 func (v Bool) MemoryLower(s *Store, offset uint32) (length uint32) {
-	res := 0
+	res := byte(0)
 	if v {
 		res = 1
 	}
-	ok := s.Memory.Write(offset, []byte{byte(res)})
+
+	ok := s.Memory.Write(offset, []byte{res})
 	if !ok {
 		s.Error = ErrMemRead
 		return 0


### PR DESCRIPTION
This PR adds a new type `wypes.Result` to be able to accommodate the component model's `Result[Shape, OK, Error]` type.

See https://github.com/bytecodealliance/wasm-tools-go/blob/main/cm/result.go

Also added the `MemoryLiftLower` implementation to several existing types such as `Bytes`, `String`, and `List[T]`.