### PR TITLE
fix: correct location for lift/lower for Result type to point to module allocated memory

### DIFF
--- a/types_mem_test.go
+++ b/types_mem_test.go
@@ -280,7 +280,7 @@ func TestResultOKStringUInt32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 	save := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{
 		IsError: false,
-		OK:      wypes.String{Raw: "awesome"},
+		OK:      wypes.String{Raw: "awesome that this is working the way I want it to"},
 		Error:   wypes.UInt32(0),
 		Offset:  64,
 		DataPtr: 128,
@@ -291,7 +291,7 @@ func TestResultOKStringUInt32(t *testing.T) {
 	result := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{}.Lift(&store)
 
 	is.Equal(c, result.IsError, false)
-	is.Equal(c, result.OK.Unwrap(), "awesome")
+	is.Equal(c, result.OK.Unwrap(), "awesome that this is working the way I want it to")
 }
 
 func TestResultErrStringUInt32(t *testing.T) {
@@ -300,7 +300,7 @@ func TestResultErrStringUInt32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 	save := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{
 		IsError: true,
-		OK:      wypes.String{Raw: "awesome"},
+		OK:      wypes.String{Raw: "awesome that this is working the way I want"},
 		Error:   wypes.UInt32(100),
 		Offset:  64,
 		DataPtr: 128,
@@ -357,9 +357,13 @@ func TestResultOKBytes(t *testing.T) {
 	c := is.NewRelaxed(t)
 	stack := wypes.NewSliceStack(4)
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+	data := make([]byte, 0, 256)
+	for i := 0; i < 256; i++ {
+		data = append(data, byte(i))
+	}
 	save := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{
 		IsError: false,
-		OK:      wypes.Bytes{Raw: []byte{1, 2, 3, 4, 5}},
+		OK:      wypes.Bytes{Raw: data},
 		Error:   wypes.UInt32(0),
 		Offset:  64,
 		DataPtr: 128,
@@ -370,5 +374,23 @@ func TestResultOKBytes(t *testing.T) {
 	result := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{}.Lift(&store)
 
 	is.Equal(c, result.IsError, false)
-	is.SliceEqual(c, result.OK.Raw, []byte{1, 2, 3, 4, 5})
+	is.SliceEqual(c, result.OK.Raw, data)
+}
+
+func TestResultErrBytes(t *testing.T) {
+	c := is.NewRelaxed(t)
+	stack := wypes.NewSliceStack(4)
+	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
+	save := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{
+		IsError: true,
+		Error:   wypes.UInt32(2),
+		Offset:  64,
+		DataPtr: 128,
+	}
+
+	save.Lower(&store)
+	store.Stack.Push(64)
+	result := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{}.Lift(&store)
+
+	is.Equal(c, result.IsError, true)
 }


### PR DESCRIPTION
This PR is fix for a major bug in lift/lower for the `Result` type to point to module allocated memory allocated memory instead of stack memory, which is the correct location.

Basically it was kinda working before as long as the data being returned was small enough, but this was incorrect.

It explains the reason for the apparent data corruption in larger strings or byte buffers. Wrong memory location!