### PR TITLE
Revert "fix: correct location for lift/lower for Result type to point to module allocated memory"

### DIFF
--- a/types_mem.go
+++ b/types_mem.go
@@ -442,20 +442,9 @@ func (Result[Shape, OK, Err]) Lift(s *Store) Result[Shape, OK, Err] {
 	var B UInt32
 	isError, sz := B.MemoryLift(s, offset)
 
-	buf, ok := s.Memory.Read(offset+sz, 4)
-	if !ok {
-		s.Error = ErrMemRead
-		return Result[Shape, OK, Err]{
-			IsError: true,
-			Offset:  offset + sz,
-		}
-	}
-
-	ptr := binary.LittleEndian.Uint32(buf[0:])
-
 	if isError > 0 {
 		var E Err
-		err, _ := E.MemoryLift(s, ptr)
+		err, _ := E.MemoryLift(s, offset+sz)
 		return Result[Shape, OK, Err]{
 			IsError: true,
 			Error:   err,
@@ -464,7 +453,7 @@ func (Result[Shape, OK, Err]) Lift(s *Store) Result[Shape, OK, Err] {
 	}
 
 	var T OK
-	val, _ := T.MemoryLift(s, ptr)
+	val, _ := T.MemoryLift(s, offset+sz)
 	return Result[Shape, OK, Err]{
 		IsError: false,
 		OK:      val,
@@ -489,14 +478,10 @@ func (v Result[Shape, OK, Err]) Lower(s *Store) {
 
 	switch v.IsError {
 	case true:
-		v.Error.MemoryLower(s, v.DataPtr)
+		v.Error.MemoryLower(s, v.Offset+sz)
 	case false:
-		v.OK.MemoryLower(s, v.DataPtr)
+		v.OK.MemoryLower(s, v.Offset+sz)
 	}
-
-	ptrdata := make([]byte, 4)
-	binary.LittleEndian.PutUint32(ptrdata[0:], v.DataPtr)
-	s.Memory.Write(v.Offset+sz, ptrdata)
 }
 
 // TODO: fixed-width array

--- a/types_mem_test.go
+++ b/types_mem_test.go
@@ -280,7 +280,7 @@ func TestResultOKStringUInt32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 	save := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{
 		IsError: false,
-		OK:      wypes.String{Raw: "awesome that this is working the way I want it to"},
+		OK:      wypes.String{Raw: "awesome"},
 		Error:   wypes.UInt32(0),
 		Offset:  64,
 		DataPtr: 128,
@@ -291,7 +291,7 @@ func TestResultOKStringUInt32(t *testing.T) {
 	result := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{}.Lift(&store)
 
 	is.Equal(c, result.IsError, false)
-	is.Equal(c, result.OK.Unwrap(), "awesome that this is working the way I want it to")
+	is.Equal(c, result.OK.Unwrap(), "awesome")
 }
 
 func TestResultErrStringUInt32(t *testing.T) {
@@ -300,7 +300,7 @@ func TestResultErrStringUInt32(t *testing.T) {
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
 	save := wypes.Result[wypes.String, wypes.String, wypes.UInt32]{
 		IsError: true,
-		OK:      wypes.String{Raw: "awesome that this is working the way I want"},
+		OK:      wypes.String{Raw: "awesome"},
 		Error:   wypes.UInt32(100),
 		Offset:  64,
 		DataPtr: 128,
@@ -357,13 +357,9 @@ func TestResultOKBytes(t *testing.T) {
 	c := is.NewRelaxed(t)
 	stack := wypes.NewSliceStack(4)
 	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
-	data := make([]byte, 0, 256)
-	for i := 0; i < 256; i++ {
-		data = append(data, byte(i))
-	}
 	save := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{
 		IsError: false,
-		OK:      wypes.Bytes{Raw: data},
+		OK:      wypes.Bytes{Raw: []byte{1, 2, 3, 4, 5}},
 		Error:   wypes.UInt32(0),
 		Offset:  64,
 		DataPtr: 128,
@@ -374,23 +370,5 @@ func TestResultOKBytes(t *testing.T) {
 	result := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{}.Lift(&store)
 
 	is.Equal(c, result.IsError, false)
-	is.SliceEqual(c, result.OK.Raw, data)
-}
-
-func TestResultErrBytes(t *testing.T) {
-	c := is.NewRelaxed(t)
-	stack := wypes.NewSliceStack(4)
-	store := wypes.Store{Stack: stack, Memory: wypes.NewSliceMemory(1024)}
-	save := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{
-		IsError: true,
-		Error:   wypes.UInt32(2),
-		Offset:  64,
-		DataPtr: 128,
-	}
-
-	save.Lower(&store)
-	store.Stack.Push(64)
-	result := wypes.Result[wypes.Bytes, wypes.Bytes, wypes.UInt32]{}.Lift(&store)
-
-	is.Equal(c, result.IsError, true)
+	is.SliceEqual(c, result.OK.Raw, []byte{1, 2, 3, 4, 5})
 }


### PR DESCRIPTION
Reverts orsinium-labs/wypes#16

I was mistaken about how this works, my bad. Please revert...